### PR TITLE
Fix: Incorrect value for responseFormat

### DIFF
--- a/src/commonMain/kotlin/io/github/vyfor/groqkt/GroqClient.kt
+++ b/src/commonMain/kotlin/io/github/vyfor/groqkt/GroqClient.kt
@@ -179,7 +179,7 @@ class GroqClient(
                 )
                 append("model", data.model!!.id)
                 data.prompt?.let { append("prompt", it) }
-                data.responseFormat?.let { append("response_format", it.name) }
+                data.responseFormat?.let { append("response_format", it.value) }
                 data.temperature?.let { append("temperature", it.toString()) }
               },
           ) {
@@ -214,7 +214,7 @@ class GroqClient(
                       )
                       append("model", data.model!!.id)
                       data.prompt?.let { append("prompt", it) }
-                      data.responseFormat?.let { append("response_format", it.name) }
+                      data.responseFormat?.let { append("response_format", it.value) }
                       data.temperature?.let { append("temperature", it.toString()) }
                     }
               },
@@ -248,7 +248,7 @@ class GroqClient(
                 append("model", data.model!!.id)
                 data.language?.let { append("language", it) }
                 data.prompt?.let { append("prompt", it) }
-                data.responseFormat?.let { append("response_format", it.name) }
+                data.responseFormat?.let { append("response_format", it.value) }
                 data.temperature?.let { append("temperature", it.toString()) }
                 data.timestampGranularities?.let {
                   append(
@@ -296,7 +296,7 @@ class GroqClient(
                       data.url?.let { append("url", it) }
                       data.language?.let { append("language", it) }
                       data.prompt?.let { append("prompt", it) }
-                      data.responseFormat?.let { append("response_format", it.name) }
+                      data.responseFormat?.let { append("response_format", it.value) }
                       data.temperature?.let { append("temperature", it.toString()) }
                       data.timestampGranularities?.let {
                         append(


### PR DESCRIPTION
Replaced usages of `responseFormat.name` with `responseFormat.value` to ensure the correct key-value pairing in HTTP requests. This ensures compatibility with the required API specification and aligns with the expected request format.